### PR TITLE
Make the generated rails app work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,4 +46,4 @@ group :development do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,8 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2019.3)
+      tzinfo (>= 1.0.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     web-console (3.7.0)
@@ -182,4 +184,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -17,8 +17,5 @@ ActiveSupport.to_time_preserves_timezone = true
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = true
 
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = false
-
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,3 +1,5 @@
-# Use this file to templatize your application's native configuration files.
-# See the docs at https://www.habitat.sh/docs/create-packages-configure/.
-# You can safely delete this file if you don't need it.
+rails_env = "test"
+secret_key_base = "c6672d79cd0b47f03794d565003f8e2d326102b5c9162f69e3a6aaab0cd5224ff92599119703c377167f99b1d93f528cd950f9534e08d2a5f468492c6685b584"
+
+[app]
+port = 3000

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -2,3 +2,14 @@ pkg_name=sample-ruby-app
 pkg_origin=lgiancol
 pkg_version="0.1.0"
 pkg_scaffolding="core/scaffolding-ruby"
+pkg_build_deps=("core/openssl")
+
+do_prepare() {
+  do_default_prepare
+  export SECRET_KEY_BASE=$(openssl rand -hex 64)
+}
+
+do_after() {
+  do_default_after
+  unset SECRET_KEY_BASE
+}


### PR DESCRIPTION
This PR modifies the generated rails app so it will run with a ruby scaffold. It also implements a `do_before` and `do_after` because there needs to be a secret key base variable exported at build time. This key gets overridden at runtime with the default.toml vaule